### PR TITLE
Adds a roadmap

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -22,7 +22,7 @@ _NOTE: Dates of meetings subject to change._
 1. First round of community feedback on Guidelines has been compiled.
 1. First round of development has been completed, ready to report.
 
-### Meeting 5: 2016-01-03
+### Meeting 5: 2016-01-10
 
 1. Guidlines have been updated to reflect community feedback, announced publicly with call for community feedback.
 1. Second round of development has been completed, ready to report and demo.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,0 +1,49 @@
+_NOTE: Dates of meetings subject to change._
+
+### Meeting 1: 11/08/2016
+
+* Charter, scope and deliverables, collaboration tools, and frequency of meetings, have been agreed on.
+
+### Meeting 2: 2016-11-22
+
+1. Roadmap has been agreed on.
+1. Initial set of user stories for Guidelines have been agreed on and documented.
+1. Candidates for proof-of-concept Hydra plugin projects have been agreed on.
+
+### Meeting 3: 2016-12-06
+
+1. Initial development on proof-of-concept Hydra plugin projects has started, including:
+  * repositories have been created
+  * initial tickets have been created
+1. v0.1 of "Hydra Plugin Development Guidelines" has been published and announced publicly, with a call for community feedback.
+
+### Meeting 4: 2016-12-20
+
+1. First round of community feedback on Guidelines has been compiled.
+1. First round of development has been completed, ready to report.
+
+### Meeting 5: 2016-01-03
+
+1. Guidlines have been updated to reflect community feedback, announced publicly with call for community feedback.
+1. Second round of development has been completed, ready to report and demo.
+
+### Meeting 6: 2016-01-17
+
+1. Second round of community feedback on Guidelines has been compiled.
+1. Third round of development has been completed, ready to report and demo.
+
+### Meeting 7: 2016-01-31
+
+1. Release candidate for Hydra Plugin Guidelines has been tagged, announced publicly, and call for community feedback.
+1. Fourth round of development has been completed, ready to report and demo.
+
+### Meeting 8: 2016-02-14
+
+1. v1.x of Guidelines have been published.
+1. Release candidates for proof-of-concept Hydra plugin projects have been tagged.
+
+### Post-sunset work TBD
+
+1. Summary report of work completed.
+1. Announce summary report on appropriate channels.
+1. Present summary report at appropriate venues.


### PR DESCRIPTION
Roadmap should serve as a list of milestones that we can refer to see if we're on schedule for completing our deliverables.

It is a working document, and may be amended. Doing so, however, is effectively 'moving the goalposts', so we should try to avoid it.