### PR TITLE
Remove contingency language from 'should' statements

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -12,7 +12,7 @@ These guidelines are supplementary, and subordinate, to existing guidelines that
 
 1. Plugins **must** be Ruby gems.
 
-1. Plugins **should** be Railties or Rails engines unless there is good reason to do otherwise.
+1. Plugins **should** be Railties or Rails engines.
 
 1. Plugins **must** have a unique namespace under which classes and modules are defined.
 


### PR DESCRIPTION
Using 'should' is enough, no additional contingency language is needed. This applies to all guidelines.

This is in response to feedback from @mjgiarlo on PR #16.